### PR TITLE
update links to schedule and team

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -7,9 +7,9 @@ parts:
   chapters:
     - file: application
     - title: Schedule
-      url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=schedule
+      url: https://snowex.hackweek.io//index.html?jump_to=schedule
     - title: Team
-      url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=team
+      url: https://snowex.hackweek.io//index.html?jump_to=team
     - file: mission
     - file: CoC
 - caption: Preparation


### PR DESCRIPTION
The Jupyter Book had links to the template website for the schedule and team links. This PR modifies to the snowex website.