### PR TITLE
attempt to change pytools version

### DIFF
--- a/conda/conda-linux-64.lock.yml
+++ b/conda/conda-linux-64.lock.yml
@@ -285,7 +285,7 @@ dependencies:
   - async-timeout=4.0.2=pyhd8ed1ab_0
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
   - binaryornot=0.4.4=py_1
-  - bleach=5.0.0=pyhd8ed1ab_0
+  - bleach=5.0.1=pyhd8ed1ab_0
   - brotlipy=0.7.0=py310h5764c6d_1004
   - cftime=1.6.0=py310hde88566_1
   - click-log=0.3.2=pyh9f0ad1d_0
@@ -432,4 +432,4 @@ dependencies:
   - pip:
     - jinja-markdown === 1.210911 
     - snowexsql === 0.2.0
-    - uavsar_pytools === 0.5.0
+    - uavsar_pytools === 0.6.1

--- a/conda/conda-lock.yml
+++ b/conda/conda-lock.yml
@@ -3790,14 +3790,14 @@ package:
     six: '>=1.9.0'
     webencodings: ''
   hash:
-    md5: 2a2ae7c56b8f72caba261363407b484a
-    sha256: 534fbfbb6f224cfd3ce91be098ee6d2a8c978135a11e9a2cd8d6c8907ccd28f3
+    md5: 1f5151d37e4a2b1137f81c89a3a769f2
+    sha256: b85dd43a40efd13c860086365d181eb9bc64cc757c36a05edc7544c3fa622bf8
   manager: conda
   name: bleach
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.0-pyhd8ed1ab_0.tar.bz2
-  version: 5.0.0
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.1-pyhd8ed1ab_0.tar.bz2
+  version: 5.0.1
 - category: main
   dependencies:
     cffi: '>=1.0.0'
@@ -9754,14 +9754,14 @@ package:
     six: '>=1.9.0'
     webencodings: ''
   hash:
-    md5: 2a2ae7c56b8f72caba261363407b484a
-    sha256: 534fbfbb6f224cfd3ce91be098ee6d2a8c978135a11e9a2cd8d6c8907ccd28f3
+    md5: 1f5151d37e4a2b1137f81c89a3a769f2
+    sha256: b85dd43a40efd13c860086365d181eb9bc64cc757c36a05edc7544c3fa622bf8
   manager: conda
   name: bleach
   optional: false
   platform: osx-64
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.0-pyhd8ed1ab_0.tar.bz2
-  version: 5.0.0
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.1-pyhd8ed1ab_0.tar.bz2
+  version: 5.0.1
 - category: main
   dependencies:
     cffi: '>=1.0.0'

--- a/conda/conda-osx-64.lock.yml
+++ b/conda/conda-osx-64.lock.yml
@@ -269,7 +269,7 @@ dependencies:
   - async-timeout=4.0.2=pyhd8ed1ab_0
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
   - binaryornot=0.4.4=py_1
-  - bleach=5.0.0=pyhd8ed1ab_0
+  - bleach=5.0.1=pyhd8ed1ab_0
   - brotlipy=0.7.0=py310h1961e1f_1004
   - click-log=0.3.2=pyh9f0ad1d_0
   - click-plugins=1.1.1=py_0
@@ -417,4 +417,4 @@ dependencies:
   - pip:
     - jinja-markdown === 1.210911 
     - snowexsql === 0.2.0
-    - uavsar_pytools === 0.5.0
+    - uavsar_pytools === 0.6.1

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -67,7 +67,7 @@ dependencies:
     - jinja-markdown==1.210911
     # NOTE: installed in lock_environment.sh
     # - snowexsql==0.2.0
-    # - uavsar_pytools==0.5.0
+    # - uavsar_pytools==0.6.1
 
 platforms:
   - linux-64


### PR DESCRIPTION
Tried to change the version of pytools used.

First tried to just edit yml and lock but got a key error - matplotlib-base error. Seems like it is a known issue with mixed conda, python imports. 

https://github.com/conda-incubator/conda-lock/issues/179#issuecomment-1134470426

So I just edited the version directly in all three files. Should I have instead put the changes in a requirement.in file and run `pip-compile --generate-hashes requirements.in > conda-linux-64.lock.yml` and `pip-compile --generate-hashes requirements.in > conda-osx-64.lock.yml`?